### PR TITLE
Require Python 3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     packages=find_packages(),
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     include_package_data=True,
     install_requires=[
         "openai==0.27.0",


### PR DESCRIPTION
`python-dotenv` 1.0.0 requires Python 3.8