### PR TITLE
deduplicate semanticScholar outputs 

### DIFF
--- a/autoresearcher/data_sources/web_apis/semantic_scholar_loader.py
+++ b/autoresearcher/data_sources/web_apis/semantic_scholar_loader.py
@@ -35,6 +35,8 @@ class SemanticScholarLoader(BaseWebAPIDataLoader):
 
         sorted_papers = sorted(papers, key=lambda x: x['combined_score'], reverse=True)
 
-        return sorted_papers[:top_n]
-    
+        # deduplicate paper entries prior to taking top n results
+        sorted_dedup_papers = list({ each_paper['paperId'] : each_paper for each_paper in sorted_papers }.values())
+
+        return sorted_dedup_papers[:top_n]    
     


### PR DESCRIPTION
Hello @eimenhmdt ! thanks for the awesome work on autoresearcher !

I noticed that there were a lot of duplicates in the SemanticScholar output from `fetch_and_sort_papers()`, meaning you might only retrieve 10 or so unique papers out of the top 20 list. I've added a line to `fetch_and_sort_papers()` prior to returning the top 20, which deduplicates the paper list based on the `paperId` field, resulting in 20 unique top papers :)

Here is a gist which shows the before and after, you definitely get a little more information out of it!

https://gist.github.com/sanjaynagi/76148e50fbeae082be609fae529b3883